### PR TITLE
Allow using POJO actions along with functional side effect

### DIFF
--- a/src/processSideEffects.js
+++ b/src/processSideEffects.js
@@ -25,7 +25,7 @@ export default function processSideEffects(next) {
       const { meta: { sideEffects } = {} } = lastAction;
 
       if (Array.isArray(sideEffects)) {
-        sideEffects.concat().forEach(sideEffect => sideEffect(store.dispatch));
+        sideEffects.concat().forEach(sideEffect => (typeof sideEffect === 'function') ? sideEffect(store.dispatch) : store.dispatch(sideEffect));
       }
     });
 

--- a/test/processSideEffects.js
+++ b/test/processSideEffects.js
@@ -119,4 +119,55 @@ describe('processSideEffects', () => {
       }
     }, 0);
   });
+  
+  it('should dispatch sideEffects action', (done) => {
+    const sideEffectAction = newAction();
+
+    const action = newAction({
+      meta: {
+        sideEffects: [ sideEffectAction ]
+      }
+    });
+
+    enhancedStore.dispatch(action);
+
+    setTimeout(() => {
+      try {
+        expect(nextStoreDispatchSpy).to.have.been.called.exactly(2);
+        expect(nextStoreDispatchSpy).to.have.been.called.with(action);
+        expect(nextStoreDispatchSpy).to.have.been.called.with(sideEffectAction);
+        done();
+      }
+      catch(e) {
+        done(e);
+      }
+    }, 0);
+  });
+
+  it('should execute all of the action\'s sideEffects and dispatch sideEffects actions', (done) => {
+    const firstSideEffectSpy = chai.spy();
+    const secondSideEffectAction = newAction();
+
+    const action = newAction({
+      meta: {
+        sideEffects: [ firstSideEffectSpy, secondSideEffectAction ]
+      }
+    });
+
+    enhancedStore.dispatch(action);
+
+    setTimeout(() => {
+      try {
+        expect(firstSideEffectSpy).to.have.been.called.exactly(1);
+        expect(nextStoreDispatchSpy).to.have.been.called.exactly(2);
+        expect(nextStoreDispatchSpy).to.have.been.called.with(action);
+        expect(nextStoreDispatchSpy).to.have.been.called.with(secondSideEffectAction);
+        done();
+      }
+      catch(e) {
+        done(e);
+      }
+    }, 0);
+  });
+
 });


### PR DESCRIPTION
Hi John,
Firstly, thank you for your great extension!
I want to improve it a little bit. The main motivation is to keep actions as plain javascript objects. It helps us with unit testing and make actions entirely declarative.
Thanks
